### PR TITLE
Refactor command line options

### DIFF
--- a/lib/doc_juan/command_line_options.rb
+++ b/lib/doc_juan/command_line_options.rb
@@ -28,7 +28,7 @@ module DocJuan
     end
 
     def to_argument_string
-      Hash[normalize_options(options).sort].to_a.flatten.compact.join(' ')
+      normalize_options(options).to_a.flatten.compact.join(' ')
     end
 
     def [](key)

--- a/lib/doc_juan/pdf.rb
+++ b/lib/doc_juan/pdf.rb
@@ -34,7 +34,7 @@ module DocJuan
     end
 
     def identifier
-      @identifier ||= Digest::MD5.hexdigest [url, command_line_options.to_argument_string].join(' ')
+      @identifier ||= Digest::MD5.hexdigest [url, options.sort.join].join('-')
     end
 
     def command_line_options

--- a/spec/command_line_options_spec.rb
+++ b/spec/command_line_options_spec.rb
@@ -29,9 +29,9 @@ describe DocJuan::CommandLineOptions do
     end
   end
 
-  it 'normalizes options and sorts them when used as arguments' do
-    clo = DocJuan::CommandLineOptions.new weight: 10, paper_size: 'A4', color: 'black', whitespace: true
-    clo.to_argument_string.must_equal '--color "black" --paper-size "A4" --weight "10" --whitespace'
+  it 'normalizes options when used as arguments' do
+    clo = DocJuan::CommandLineOptions.new weight: 10, paper_size: 'A4', whitespace: true
+    clo.to_argument_string.must_equal '--weight "10" --paper-size "A4" --whitespace'
   end
 
   it 'allows access to values by key' do

--- a/spec/pdf_spec.rb
+++ b/spec/pdf_spec.rb
@@ -16,10 +16,11 @@ describe DocJuan::Pdf do
     DocJuan::Pdf.new(url, filename, options)
   end
 
-  it 'has a unique identifier' do
-    pdf = DocJuan::Pdf.new(url, filename, options)
+  it 'has a unique identifier created by the url and sorted options' do
+    pdf = DocJuan::Pdf.new url, filename
+    pdf.stubs(:options).returns size: 'A5', lowquality: true
 
-    pdf.identifier.must_equal '71ff89abc1094cff8c216841028755b1'
+    pdf.identifier.must_equal Digest::MD5.hexdigest 'http://example.com-lowqualitytruesizeA5'
   end
 
   it 'strips junk from the filename' do


### PR DESCRIPTION
CommandLineOptions should not care about sorting options

Removed pollution of to_s conventions for CommandLineOptions
