### PR TITLE
Use Rack::Sendfile instead of directly setting X-Accel-Redirect

### DIFF
--- a/lib/doc_juan/app.rb
+++ b/lib/doc_juan/app.rb
@@ -1,8 +1,10 @@
 require 'sinatra/base'
+require 'rack/sendfile'
 require_relative 'auth'
 
 module DocJuan
   class App < Sinatra::Base
+    use Rack::Sendfile
 
     enable :logging
 
@@ -32,10 +34,8 @@ module DocJuan
       renderer = renderer_class.new params[:url], params[:filename], params[:options]
       result = renderer.generate
 
-      headers['Content-Type'] = result.mime_type
-      headers['Content-Disposition'] = "inline; filename=\"#{result.filename}\""
-      headers['Cache-Control'] = 'public,max-age=2592000'
-      headers['X-Accel-Redirect'] = result.path
+      cache_control :public, max_age: 2592000
+      send_file result.path, type: result.mime_type, disposition: :inline, filename: result.filename
     end
 
     get '/robots.txt' do


### PR DESCRIPTION
This requires a change in the NGiNX configuration so that Rack::Sendfile is made aware that it should add the X-Accel-Redirect header and omit the file body. See: https://github.com/rack/rack/blob/1.6.0/lib/rack/sendfile.rb#L44-L45

The advantage to this is that it makes Doc-Juan work with any local dev server. If the proxy pass header is not present, Doc-Juan will instead simply serve up the file in the request body. This means that we get the same performance win in production of having NGiNX serve the file, but we do not have to do anything special in development mode.

Also, the code just reads nicer ;)
